### PR TITLE
Support test suites

### DIFF
--- a/test/example.spectest.js
+++ b/test/example.spectest.js
@@ -1,0 +1,12 @@
+const suite = [
+  {
+    name: "Fetch album 1",
+    endpoint: "/albums/1",
+  },
+  {
+    name: "Fetch photo 1",
+    endpoint: "/photos/1",
+  }
+];
+export default suite;
+


### PR DESCRIPTION
## Summary
- track suite name by test file and attach suiteName to each test case
- group results by suite when printing
- include suite names in snapshots
- add example test suite for verifying multi-suite support
- fix suite name extraction when files don't end with `.spectest.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871d51d98b4832690a104dce8684372