### PR TITLE
Add support for suite objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create the file `test/jsonpayload.spectest.js` and paste the code below in it. *
 ```js
 // jsonpayload.spectest.js
 
-const suite = [
+const tests = [
   // This basic example fetches {baseUrl}/todos/1 and asserts response status is 'OK'.
   {
     name: "Fetch TODO 1",
@@ -63,10 +63,11 @@ const suite = [
     },
   },
 ];
-export default suite;
+
+export default { name: 'jsonpayload', tests };
 ```
 
-A `*.spectest.js` file can have `classes`, `functions`, use `imports` and do anything you would with Javascript. It simply needs to export an array of test cases in the end, how it builds this array is up to it. For the full schema of a test case, see [Testcase reference](#test-case-options)
+A `*.spectest.js` file can have `classes`, `functions`, use `imports` and do anything you would with Javascript. The default export may be either an array of test cases or an object with a `tests` array and optional `name` property. For the full schema of a test case, see [Testcase reference](#test-case-options)
 
 ### 3. Run the test cases
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,10 +46,27 @@ async function discoverSuites(cfg) {
 
   async function loadSuite(filePath: string) {
     const mod = await import(filePath);
-    const tests = Array.isArray(mod.default) ? [...mod.default] : [];
-    const base = path.basename(filePath);
-    const parsed = path.parse(base);
-    const name = parsed.name.replace(/\.spectest$/, '');
+    const exported = mod.default || mod;
+    let tests: any[] = [];
+    let name: string | undefined;
+
+    if (Array.isArray(exported)) {
+      tests = [...exported];
+    } else if (exported && typeof exported === 'object') {
+      if (Array.isArray((exported as any).tests)) {
+        tests = [...(exported as any).tests];
+      }
+      if (typeof (exported as any).name === 'string') {
+        name = (exported as any).name;
+      }
+    }
+
+    if (!name) {
+      const base = path.basename(filePath);
+      const parsed = path.parse(base);
+      name = parsed.name.replace(/\.spectest$/, '');
+    }
+
     return { name, tests };
   }
 

--- a/test/example.spectest.js
+++ b/test/example.spectest.js
@@ -1,4 +1,4 @@
-const suite = [
+const tests = [
   {
     name: "Fetch album 1",
     endpoint: "/albums/1",
@@ -8,5 +8,6 @@ const suite = [
     endpoint: "/photos/1",
   }
 ];
-export default suite;
+
+export default { name: "example", tests };
 


### PR DESCRIPTION
## Summary
- support loading suite modules that export `{ name, tests }`
- update README to document object-form suites
- update example suite to use new object form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872309952508326a13aab593d86213b