### PR TITLE
Add optional operationId to test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ That’s where Spectest was born—out of necessity.
 | Option | Description | Default |
 | ------ | ----------- | ------- |
 | `name` | Human readable test name | required |
+| `operationId` | Unique identifier for the operation | `name` |
 | `endpoint` | Request path relative to the base URL | required |
 | `request.method` | HTTP method | `GET` |
 | `request.headers` | Additional request headers | none |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -231,6 +231,7 @@ async function runTest(test) {
       latency,
       requestId,
       testName: test.name,
+      operationId: test.operationId,
       suiteName: test.suiteName,
       request: config,
       response: {
@@ -248,6 +249,7 @@ async function runTest(test) {
       latency,
       requestId,
       testName: test.name,
+      operationId: test.operationId,
       suiteName: test.suiteName,
       timedOut: isTimeout,
       request: error.config || undefined,
@@ -464,6 +466,10 @@ async function runAllTests(cfg, verbose = false, tags = []) {
     suite.tests.map((t) => ({ ...t, suiteName: suite.name }))
   );
 
+  tests.forEach((t) => {
+    if (!t.operationId) t.operationId = t.name;
+  });
+
   // TODO: Do not proceed if tests array is empty.
 
   try {
@@ -504,6 +510,7 @@ async function runAllTests(cfg, verbose = false, tags = []) {
   if (cfg.snapshotFile) {
     const snapshotCases = testResults.map((r) => ({
       name: r.testName,
+      operationId: r.operationId,
       suite: r.suiteName,
       request: r.request,
       response: r.response,

--- a/src/generate-openapi.ts
+++ b/src/generate-openapi.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 interface TestCase {
   name: string;
   endpoint: string;
+  operationId?: string;
   request?: {
     method?: string;
     headers?: Record<string, string>;
@@ -27,7 +28,7 @@ async function loadSuites(testDir = './spec', filePattern = /\.(suite|suites)\./
   return modules.reduce<TestCase[]>((acc, mod) => {
     if (Array.isArray(mod.default)) acc.push(...mod.default);
     return acc;
-  }, []);
+  }, []).map((t) => ({ ...t, operationId: t.operationId || t.name }));
 }
 
 function dedupeTests(tests: TestCase[]): TestCase[] {
@@ -62,6 +63,7 @@ export async function generateOpenApi() {
     spec.paths[pathKey] = spec.paths[pathKey] || {};
     const op: any = {
       summary: test.name,
+      operationId: test.operationId || test.name,
       responses: {},
     };
 


### PR DESCRIPTION
## Summary
- support an optional `operationId` for test cases
- default `operationId` to the test `name`
- include `operationId` in snapshots and OpenAPI generation
- document `operationId` option

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68775cf4292c8326ab0ab66687714bef