### PR TITLE
Rename order param to batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ That’s where Spectest was born—out of necessity.
 | `response.*` | Other valid fetch [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) response keys e.g. `statusText`, `type`. | none |
 | `beforeSend` | Function used to finalize the request | none |
 | `postTest` | Function used to process response, usually to extract and save data. | none |
-| `order` | Execution order for grouping tests | `0` |
+| `batch` | Batch number for grouping tests | `0` |
 | `tags` | Tags used for filtering | none |
 | `skip` | Skip the test case | `false` |
 | `focus` | Run only focused tests when present | `false` |
 | `repeat` | Extra sequential runs of the test | `0` |
-| `bombard` | Additional runs at the same order | `0` |
+| `bombard` | Additional runs in the same batch | `0` |
 | `delay` | Milliseconds to wait before running | none |
 | `timeout` | Per-test timeout override | runtime `timeout` (30000ms) |
 
@@ -209,7 +209,7 @@ By default, test requests are sent in parallel, if your API calls other APIs dur
 
 ### Testing multi-step flows
 
-The `order` test case parameter forces tests to be executed in pre-defined order. By default all tests execute have `order` of `0`, a test case with `order > 0` will execute after all cases with `order == 0`.
+The `batch` test case parameter forces tests to be executed in pre-defined order. By default all tests have a `batch` of `0`, a test case with `batch > 0` will execute after all cases with `batch == 0`.
 
 The test case `postTest` function can be used to extract and save data from a test case.<br>
 In a similar vein, the test case `beforeSend` function can be used make final runtime modifications to a request before send.
@@ -229,7 +229,7 @@ export default [
       body: { username: 'admin', password: 'secret' }
     },
     postTest: async ({ json }) => { token = json.token; },
-    order: 0,
+    batch: 0,
   },
   {
     name: 'Fetch profile',
@@ -238,7 +238,7 @@ export default [
       req.headers = { ...req.headers, Authorization: `Bearer ${token}` };
     },
     response: { status: 200 }
-    order: 1,
+    batch: 1,
   }
 ];
 ```
@@ -302,7 +302,7 @@ Use the `timeout` option to limit how long each test case may run. Specify `time
 
 ### Check for robustness of API
 
-* **Randomize tests**: Run tests with `--randomize` to uncover unexpected test order dependencies. Randomization doesn't affect tests with explicitly declared order, using `order`. This is especially useful for serverless functions, that should be stateless.
+* **Randomize tests**: Run tests with `--randomize` to uncover unexpected batch order dependencies. Randomization doesn't affect tests with explicitly declared batches, using `batch`. This is especially useful for serverless functions, that should be stateless.
 
 * **Load testing**: Use the `--bombard` parameter to literally bombard the API with requests. It can also be set at the individual test case level to determine how an API would handle a flooding of that endpoint.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -262,14 +262,14 @@ async function runTest(test) {
   }
 }
 
-function groupTestsByOrder(tests) {
+function groupTestsByBatch(tests) {
   const testGroups = new Map();
   tests.forEach((test) => {
-    const order = test.order ?? 0;
-    if (!testGroups.has(order)) {
-      testGroups.set(order, []);
+    const batch = test.batch ?? 0;
+    if (!testGroups.has(batch)) {
+      testGroups.set(batch, []);
     }
-    testGroups.get(order).push(test);
+    testGroups.get(batch).push(test);
   });
   return new Map([...testGroups.entries()].sort(([a], [b]) => a - b));
 }
@@ -279,17 +279,17 @@ function expandRepeats(tests) {
     const repeat = Number.isFinite(Number(test.repeat)) ? Number(test.repeat) : 0;
     const bombard = Number.isFinite(Number(test.bombard)) ? Number(test.bombard) : 0;
     const totalRuns = repeat + 1;
-    const baseOrder = test.order ?? 0;
+    const baseBatch = test.batch ?? 0;
 
     const repeated = Array.from({ length: totalRuns }).map((_, idx) => {
       if (idx === 0) {
         // eslint-disable-next-line no-param-reassign
-        test.order = baseOrder;
+        test.batch = baseBatch;
         return test;
       }
       const clone = Object.assign(Object.create(Object.getPrototypeOf(test)), test);
       clone.name = `(Run ${idx + 1}) ${test.name}`;
-      clone.order = baseOrder + idx;
+      clone.batch = baseBatch + idx;
       return clone;
     });
 
@@ -299,7 +299,7 @@ function expandRepeats(tests) {
         if (bIdx === 0) return t;
         const clone = Object.assign(Object.create(Object.getPrototypeOf(t)), t);
         clone.name = `(Bombard ${bIdx + 1}) ${t.name}`;
-        clone.order = t.order;
+        clone.batch = t.batch;
         return clone;
       });
     });
@@ -417,7 +417,7 @@ async function runTestsInOrder(tests, renderer, options = {}) {
     }
   }
   const happyResult = filterTestsByHappy(nameResult.filtered, happyFlag);
-  const testGroups = groupTestsByOrder(happyResult.filtered);
+  const testGroups = groupTestsByBatch(happyResult.filtered);
   const skippedTests = [
     ...focusResult.skipped,
     ...tagResult.skipped,
@@ -425,7 +425,7 @@ async function runTestsInOrder(tests, renderer, options = {}) {
     ...happyResult.skipped,
   ];
   const initial = Promise.resolve({ results: [], bail: false });
-  const final = await Array.from(testGroups).reduce(async (accPromise, [order, testsInGroup]) => {
+  const final = await Array.from(testGroups).reduce(async (accPromise, [batch, testsInGroup]) => {
     const accumulator = await accPromise;
     if (accumulator.bail) {
       skippedTests.push(...testsInGroup);
@@ -438,7 +438,7 @@ async function runTestsInOrder(tests, renderer, options = {}) {
     if (randomize) {
       shuffle(runnableTests);
     }
-    renderer.runningOrder(order, runnableTests.length);
+    renderer.runningBatch(batch, runnableTests.length);
     const groupResults = await Promise.all(
       runnableTests.map(async (test) => {
         const result = await runTest(test);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -42,25 +42,25 @@ function seq(tests) {
   if (tests.length === 0) return tests;
 
   const first = tests[0];
-  let lastOrder = typeof first.order === "number" ? first.order : 0;
+  let lastBatch = typeof first.batch === "number" ? first.batch : 0;
 
-  if (typeof first.order !== "number") {
-    first.order = lastOrder;
+  if (typeof first.batch !== "number") {
+    first.batch = lastBatch;
   }
 
   for (let i = 1; i < tests.length; i += 1) {
     const test = tests[i];
-    if (typeof test.order === "number") {
-      if (test.order > lastOrder) {
-        lastOrder = test.order;
-        // keep predefined order if it maintains sequence
+    if (typeof test.batch === "number") {
+      if (test.batch > lastBatch) {
+        lastBatch = test.batch;
+        // keep predefined batch if it maintains sequence
       } else {
-        lastOrder += 1;
-        test.order = lastOrder;
+        lastBatch += 1;
+        test.batch = lastBatch;
       }
     } else {
-      lastOrder += 1;
-      test.order = lastOrder;
+      lastBatch += 1;
+      test.batch = lastBatch;
     }
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -18,8 +18,8 @@ export default class Renderer {
     console.log('='.repeat(50));
   }
 
-  runningOrder(order: number, count: number): void {
-    console.log(`📋 Running tests with order ${order} (${count} tests)...`);
+  runningBatch(batch: number, count: number): void {
+    console.log(`📋 Running batch ${batch} (${count} tests)...`);
   }
 
   showSkippedTests(skipped: any[]): void {


### PR DESCRIPTION
## Summary
- rename test `order` parameter to `batch`
- update helper utilities and CLI to group tests by batch
- adjust renderer output
- document new `batch` parameter in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6877d28b2b7c8326b4de3f3bd286ddc9