### PR TITLE
Implement dependsOn test ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ That’s where Spectest was born—out of necessity.
 | ------ | ----------- | ------- |
 | `name` | Human readable test name | required |
 | `operationId` | Unique identifier for the operation | `name` |
+| `dependsOn` | Array of `operationId` strings that must pass before this test runs | none |
 | `endpoint` | Request path relative to the base URL | required |
 | `request.method` | HTTP method | `GET` |
 | `request.headers` | Additional request headers | none |
@@ -300,6 +301,7 @@ Use the `timeout` option to limit how long each test case may run. Specify `time
 ### Check for robustness of API
 
 * **Randomize tests**: Run tests with `--randomize` to uncover unexpected test order dependencies. This is especially useful for serverless functions that should be stateless.
+* **Explicit dependencies**: Use the `dependsOn` array on a test case to run it only after the listed operations succeed.
 
 * **Load testing**: Use the `--bombard` parameter to literally bombard the API with requests. It can also be set at the individual test case level to determine how an API would handle a flooding of that endpoint.
 

--- a/test/comments.spectest.mjs
+++ b/test/comments.spectest.mjs
@@ -3,10 +3,13 @@ const suite = {
   tests: [
     {
       name: "Fetch comment 1",
+      operationId: "fetchComment1",
       endpoint: "/comments/1",
     },
     {
       name: "Fetch comment 2",
+      operationId: "fetchComment2",
+      dependsOn: ["fetchComment1"],
       endpoint: "/comments/2",
     },
   ],


### PR DESCRIPTION
## Summary
- allow tests to specify dependencies via `dependsOn`
- schedule tests based on dependencies and skip dependents if a prior test fails
- document the new option in the README
- demonstrate `dependsOn` in sample tests

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68789ba0d5f48326b79aabba28d073e4