### PR TITLE
Improve dependsOn test scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ That’s where Spectest was born—out of necessity.
 | ------ | ----------- | ------- |
 | `name` | Human readable test name | required |
 | `operationId` | Unique identifier for the operation | `name` |
+| `dependsOn` | Array of `operationId` strings that must pass before this test runs | none |
 | `endpoint` | Request path relative to the base URL | required |
 | `request.method` | HTTP method | `GET` |
 | `request.headers` | Additional request headers | none |
@@ -300,6 +301,7 @@ Use the `timeout` option to limit how long each test case may run. Specify `time
 ### Check for robustness of API
 
 * **Randomize tests**: Run tests with `--randomize` to uncover unexpected test order dependencies. This is especially useful for serverless functions that should be stateless.
+* **Explicit dependencies**: Use the `dependsOn` array on a test case to run it only after the listed operations succeed. Independent tests run concurrently as their prerequisites complete.
 
 * **Load testing**: Use the `--bombard` parameter to literally bombard the API with requests. It can also be set at the individual test case level to determine how an API would handle a flooding of that endpoint.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -415,8 +415,64 @@ async function runTests(tests, renderer, options = {}) {
     shuffle(runnableTests);
   }
 
-  const results = await Promise.all(runnableTests.map((t) => runTest(t)));
-  return { results, skippedTests };
+  const opIdMap = new Map<string, any>();
+  runnableTests.forEach((t) => {
+    opIdMap.set(t.operationId, t);
+    t.dependents = [];
+    t.unresolvedDependencies = 0;
+    t.__runtimeSkip = false;
+  });
+
+  runnableTests.forEach((t) => {
+    if (Array.isArray(t.dependsOn) && t.dependsOn.length > 0) {
+      t.unresolvedDependencies = t.dependsOn.length;
+      t.dependsOn.forEach((depId: string) => {
+        const dep = opIdMap.get(depId);
+        if (dep) {
+          dep.dependents.push(t);
+        } else {
+          t.unresolvedDependencies -= 1;
+        }
+      });
+    }
+  });
+
+  const runtimeSkipped = new Set<any>();
+  const results: any[] = [];
+  const scheduled = new Set<any>();
+  const promises: Promise<void>[] = [];
+
+  function schedule(test: any) {
+    if (scheduled.has(test) || test.__runtimeSkip) return;
+    scheduled.add(test);
+    const p = runTest(test).then((result) => {
+      results.push(result);
+      if (!result.passed) {
+        test.dependents.forEach((d: any) => {
+          if (!d.__runtimeSkip) {
+            d.__runtimeSkip = true;
+            runtimeSkipped.add(d);
+          }
+        });
+      } else {
+        test.dependents.forEach((d: any) => {
+          d.unresolvedDependencies -= 1;
+          if (d.unresolvedDependencies === 0 && !d.__runtimeSkip) {
+            schedule(d);
+          }
+        });
+      }
+    });
+    promises.push(p);
+  }
+
+  runnableTests
+    .filter((t) => t.unresolvedDependencies === 0)
+    .forEach((t) => schedule(t));
+
+  await Promise.all(promises);
+  const skipped = [...runtimeSkipped];
+  return { results, skippedTests: [...skippedTests, ...skipped] };
 }
 
 async function runAllTests(cfg, verbose = false, tags = []) {

--- a/test/comments.spectest.mjs
+++ b/test/comments.spectest.mjs
@@ -3,10 +3,13 @@ const suite = {
   tests: [
     {
       name: "Fetch comment 1",
+      operationId: "fetchComment1",
       endpoint: "/comments/1",
     },
     {
       name: "Fetch comment 2",
+      operationId: "fetchComment2",
+      dependsOn: ["fetchComment1"],
       endpoint: "/comments/2",
     },
   ],


### PR DESCRIPTION
## Summary
- refine `dependsOn` handling to run independent tests concurrently
- document that concurrent execution is done when prerequisites are satisfied

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68789ba0d5f48326b79aabba28d073e4