### PR TITLE
Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ That’s where Spectest was born—out of necessity.
 | ------ | ----------- | ------- |
 | `configFile` | Path to an extra config file | none |
 | `baseUrl` | Base URL of the API | `http://localhost:3000` |
+| `proxy` | Proxy server URL | none |
 | `testDir` | Directory containing test suites | `./test` |
 | `filePattern` | Regex for suite filenames | `\.spectest\.` |
 | `startCmd` | Command to start the test server | `npm run start` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,23 @@ import Server from './server';
 import RateLimiter from './rate-limiter';
 import { resolveUserAgent } from './user-agents';
 
+function parseProxyUrl(url: string) {
+  try {
+    const u = new URL(url);
+    const auth = u.username
+      ? { username: decodeURIComponent(u.username), password: decodeURIComponent(u.password) }
+      : undefined;
+    return {
+      protocol: u.protocol.replace(':', ''),
+      host: u.hostname,
+      port: parseInt(u.port, 10) || (u.protocol === 'https:' ? 443 : 80),
+      auth,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 
 let api;
 let rateLimiter;
@@ -26,6 +43,7 @@ function setupEnvironment(cfg) {
     baseURL: cfg.baseUrl,
     timeout: cfg.timeout || 30000,
     validateStatus: () => true,
+    ...(cfg.proxy ? { proxy: parseProxyUrl(cfg.proxy) } : {}),
   });
   api.defaults.headers.common['User-Agent'] = resolveUserAgent(cfg.userAgent);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export interface CliConfig {
   filter?: string;
   verbose?: boolean;
   userAgent?: string;
+  proxy?: string;
   suiteFile?: string;
   projectRoot?: string;
 }
@@ -87,6 +88,9 @@ function parseArgs(argv: string[]): CliConfig {
           break;
         case 'ua':
           raw.userAgent = value;
+          break;
+        case 'proxy':
+          raw.proxy = value;
           break;
         default:
           console.error("error: unknown key " + key);

--- a/src/default.config.ts
+++ b/src/default.config.ts
@@ -10,4 +10,5 @@ export default {
   filter: '',
   runningServer: 'reuse',
   userAgent: 'chrome_windows',
+  proxy: '',
 };


### PR DESCRIPTION
## Summary
- add `proxy` option to CLI config
- parse `--proxy` param
- set axios proxy when provided
- document proxy option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687da06ec2f48326a8c879556fe1ffe8