### PR TITLE
feat: add optional server build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ That’s where Spectest was born—out of necessity.
 | `testDir` | Directory containing test suites | `./test` |
 | `filePattern` | Regex for suite filenames | `\.spectest\.` |
 | `startCmd` | Command to start the test server | `npm run start` |
+| `buildCmd` | Command to build the test server | none |
 | `runningServer` | Handling for an existing server (`reuse`, `fail`, or `kill`) | `reuse` |
 | `tags` | String list used for filtering tests | [] |
 | `rps` | Requests per second rate limit | Infinity |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ function setupEnvironment(cfg) {
 
   server.setConfig({
     startCommand: cfg.startCmd,
+    buildCmd: cfg.buildCmd,
     serverUrl: cfg.baseUrl,
     runningServer: cfg.runningServer,
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface CliConfig {
   testDir?: string;
   filePattern?: string;
   startCmd?: string;
+  buildCmd?: string;
   runningServer?: string;
   tags?: string[];
   rps?: number;
@@ -55,6 +56,9 @@ function parseArgs(argv: string[]): CliConfig {
           break;
         case 'start-cmd':
           raw.startCmd = value;
+          break;
+        case 'build-cmd':
+          raw.buildCmd = value;
           break;
         case 'running-server':
           raw.runningServer = value;


### PR DESCRIPTION
## Summary
- allow specifying a build command before server startup
- expose buildCmd through config and CLI
- document buildCmd option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689517d6bd2483268ab0534081bf705a