### PR TITLE
feat: allow overriding project root via --dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ That’s where Spectest was born—out of necessity.
 | `verbose` | Verbose output with logs | `false` |
 | `userAgent` | Browser User-Agent string to send or one of the predefined [user-agents](https://github.com/justiceo/spectest/blob/main/src/user-agents.ts). | `chrome_windows` |
 | `suiteFile` | Run only the specified suite file | none |
-| `projectRoot` | Root directory of the project | current working directory |
+| `projectRoot` (`--dir`) | Root directory of the project | current working directory |
 
 
 ## API Testing Tips


### PR DESCRIPTION
## Summary
- add `--dir` CLI flag for overriding the working directory used as project root
- resolve optional configs relative to the provided directory
- document `--dir` usage

## Testing
- `npm test`
- `node dist/cli.js --dir=. --base-url=https://jsonplaceholder.typicode.com`


------
https://chatgpt.com/codex/tasks/task_b_68959fd795548326b9d3e44de4125864