### PR TITLE
feat: add yaml test support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "spectest",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spectest",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.10.0"
+        "axios": "^1.10.0",
+        "js-yaml": "^4.1.0"
       },
       "bin": {
         "spectest": "dist/cli.js"
@@ -28,6 +29,12 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -270,6 +277,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "axios": "^1.10.0"
+    "axios": "^1.10.0",
+    "js-yaml": "^4.1.0"
   },
   "bin": {
     "spectest": "dist/cli.js"

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile } from 'fs/promises';
 import path from 'path';
+import { load as parseYaml } from 'js-yaml';
 import type { CliConfig } from './config';
 import type { Suite, TestCase } from './types';
 
@@ -29,6 +30,15 @@ async function loadSuite(filePath: string): Promise<Suite> {
       tests = data;
     } else if (data && Array.isArray(data.tests)) {
       tests = data.tests;
+      if (typeof data.name === 'string') name = data.name;
+    }
+  } else if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
+    const raw = await readFile(filePath, 'utf8');
+    const data: any = parseYaml(raw);
+    if (Array.isArray(data)) {
+      tests = data as any;
+    } else if (data && Array.isArray(data.tests)) {
+      tests = data.tests as any;
       if (typeof data.name === 'string') name = data.name;
     }
   } else {

--- a/test/posts.spectest.yaml
+++ b/test/posts.spectest.yaml
@@ -1,0 +1,6 @@
+name: Posts Tests
+tests:
+  - name: List posts
+    endpoint: /posts/
+  - name: Get post 1
+    endpoint: /posts/1


### PR DESCRIPTION
## Summary
- allow loading test suites written in YAML
- parse .yaml/.yml files to JSON using js-yaml
- document usage with a sample YAML suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6895a6e8279c83269508da9da70e68de